### PR TITLE
Run on Windows: Manage pathnames with Path and file handling with shutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/*
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 onnxruntime
 opencv-contrib-python
 opencv-python
+tqdm


### PR DESCRIPTION
I am working on Windows and encountered some errors that originated in `rtmlib.tools.file`. These were resolved by adjusting how paths were put together and by using `shutil` to handle file moving and removal rather than `os.system`.

With these slight modifications I was able to run the whole body demo successfully on Win 10 and believe this will be robust on 
Linux, though have not tested it.

I'm grateful for this project and look forward to spending more time with this code.

Thank you,

Mac


