### PR TITLE
fix creation of Body with pose=None

### DIFF
--- a/rtmlib/tools/solution/body.py
+++ b/rtmlib/tools/solution/body.py
@@ -99,7 +99,7 @@ class Body:
                  backend: str = 'onnxruntime',
                  device: str = 'cpu'):
 
-        if 'rtmo' in pose:
+        if pose is not None and 'rtmo' in pose:
             from .. import RTMO
 
             self.one_stage = True


### PR DESCRIPTION
The check `if 'rtmo' in pose` would crash with the default setting `pose=None`