### PR TITLE
Support cuda device id

### DIFF
--- a/rtmlib/tools/base.py
+++ b/rtmlib/tools/base.py
@@ -60,7 +60,12 @@ class BaseTool(metaclass=ABCMeta):
 
         elif backend == 'onnxruntime':
             import onnxruntime as ort
-            providers = RTMLIB_SETTINGS[backend][device]
+            # 'cuda:device_id'
+            if (device not in RTMLIB_SETTINGS[backend]) and ("cuda" in device):
+                device_id = int(device.split(":")[-1])
+                providers = ('CUDAExecutionProvider', {'device_id': device_id})
+            else:
+                providers = RTMLIB_SETTINGS[backend][device]
 
             self.session = ort.InferenceSession(path_or_bytes=onnx_model,
                                                 providers=[providers])


### PR DESCRIPTION
Based on your device setting for `onnxruntime`, I add a simple `if` block to handle the case if specific cuda device id is desirable.

https://github.com/Tau-J/rtmlib/blob/875c773bce0ad0225aa9cbd894a4d333fab2575b/rtmlib/tools/base.py#L24