### PR TITLE
Fix wrong output type

### DIFF
--- a/rtmlib/tools/file.py
+++ b/rtmlib/tools/file.py
@@ -133,7 +133,7 @@ def download_checkpoint(url: str,
 
     if not cached_file.exists():
         if os.path.exists(onnx_name):
-            return onnx_name
+            return str(onnx_name)
 
         sys.stderr.write('Downloading: "{}" to {}\n'.format(url, cached_file))
         hash_prefix = None


### PR DESCRIPTION
Change return type from `pathlib.PosixPath` to `str` to align with expected type in the `download_checkpoint` function.