### PR TITLE
Deprecation warning: import `openvino.runtime` -> `openvino`

### DIFF
--- a/rtmlib/tools/base.py
+++ b/rtmlib/tools/base.py
@@ -71,7 +71,7 @@ class BaseTool(metaclass=ABCMeta):
                                                 providers=[providers])
 
         elif backend == 'openvino':
-            from openvino.runtime import Core
+            from openvino import Core
             core = Core()
             model_onnx = core.read_model(model=onnx_model)
 


### PR DESCRIPTION
Deprecation warning: import `openvino.runtime` -> `openvino`:

Lib\site-packages\openvino\runtime\__init__.py:10: DeprecationWarning: The `openvino.runtime` module is deprecated and will be removed in the 2026.0 release. Please replace `openvino.runtime` with `openvino`.