### PR TITLE
fix(openvino): support GPU/NPU devices and variable output count

### DIFF
--- a/rtmlib/tools/base.py
+++ b/rtmlib/tools/base.py
@@ -35,6 +35,11 @@ RTMLIB_SETTINGS = {
         'CoreMLExecutionProvider'
         if check_mps_support() else 'CPUExecutionProvider'
     },
+    'openvino': {
+        'cpu': 'CPU',
+        'gpu': 'GPU',
+        'npu': 'NPU',
+    },
 }
 
 
@@ -85,17 +90,20 @@ class BaseTool(metaclass=ABCMeta):
             core = Core()
             model_onnx = core.read_model(model=onnx_model)
 
-            if device != 'cpu':
-                print('OpenVINO only supports CPU backend, automatically'
-                      ' switched to CPU backend.')
+            # Map device string to OpenVINO device name
+            ov_device = RTMLIB_SETTINGS['openvino'].get(
+                device, device.upper())
 
             self.compiled_model = core.compile_model(
                 model=model_onnx,
-                device_name='CPU',
+                device_name=ov_device,
                 config={'PERFORMANCE_HINT': 'LATENCY'})
             self.input_layer = self.compiled_model.input(0)
-            self.output_layer0 = self.compiled_model.output(0)
-            self.output_layer1 = self.compiled_model.output(1)
+            # Store all output layers (models may have 1, 2, or more)
+            self._ov_outputs = [
+                self.compiled_model.output(i)
+                for i in range(len(model_onnx.outputs))
+            ]
 
         else:
             raise NotImplementedError
@@ -142,8 +150,6 @@ class BaseTool(metaclass=ABCMeta):
             outputs = self.session.run(sess_output, sess_input)
         elif self.backend == 'openvino':
             results = self.compiled_model(input)
-            output0 = results[self.output_layer0]
-            output1 = results[self.output_layer1]
-            outputs = [output0, output1]
+            outputs = [results[out] for out in self._ov_outputs]
 
         return outputs


### PR DESCRIPTION
- Add 'openvino' entry to RTMLIB_SETTINGS with cpu/gpu/npu device mappings, consistent with the opencv and onnxruntime backends.

- Remove hardcoded CPU-only restriction in the openvino backend. The device string is now mapped through RTMLIB_SETTINGS to the corresponding OpenVINO device name (CPU, GPU, NPU). Unknown device strings fall back to upper-cased (e.g. 'auto' -> 'AUTO').

- Fix crash on models with != 2 outputs (e.g. YOLOX has 1 output). Output layers are now stored dynamically in _ov_outputs instead of hardcoding output_layer0 / output_layer1. The inference method iterates over all stored outputs.

Tested on Intel Core Ultra 7 165U:
  - GPU (iGPU): YOLOX-tiny, RTMPose-m body, RTMPose-m hand
  - NPU (AI Boost): all three models compile and run

Fixes: YOLOX / single-output models crash with IndexError on output(1)
Relates to: #46 (Can RTMlib run in GPU?)